### PR TITLE
(chore) added ack_packet. added id field (uint16_t) in ack_packet and…

### DIFF
--- a/rocket_packet.c
+++ b/rocket_packet.c
@@ -13,10 +13,10 @@ unsigned int serialize_avionics_data(AvionicsData* data, uint8_t* dst) {
 	 */
 	size_t i;
 	size_t offset = 0;
-	char start_char = ROCKET_PACKET_START;
+	char start_short = ROCKET_PACKET_START;
 
 	// start char
-	memcpy(dst + offset, (void *) &start_char, sizeof(char));
+	memcpy(dst + offset, (void *) &start_short, sizeof(char));
 	offset += sizeof(char);
 	// timestamp
 	memcpy(dst + offset, (void *) &data->timestamp, sizeof(data->timestamp));
@@ -69,17 +69,20 @@ unsigned int serialize_avionics_data(AvionicsData* data, uint8_t* dst) {
 unsigned int serialize_command_packet(CommandPacket* pkt, uint8_t* dst) {
 	unsigned int offset = 0;
 	
-	memcpy(dst + offset, (void *) &pkt->start_char, 2);
-	offset += 2;
+	memcpy(dst + offset, (void *) &pkt->start_short, sizeof(pkt->start_short));
+	offset += sizeof(pkt->start_short);
+
+	memcpy(dst + offset, (void *) &pkt->id, sizeof(pkt->id));
+	offset += sizeof(pkt->id);
 	
-	memcpy(dst + offset, (void *) &pkt->function, 1);
-	offset += 1;
+	memcpy(dst + offset, (void *) &pkt->function, sizeof(pkt->function));
+	offset += sizeof(pkt->function);
 	
-	memcpy(dst + offset, (void *) &pkt->arg, 1);
-	offset += 1;
+	memcpy(dst + offset, (void *) &pkt->arg, sizeof(pkt->arg));
+	offset += sizeof(pkt->arg);
 	
-	memcpy(dst + offset, (void *) &pkt->crc, 2);
-	offset += 2;
+	memcpy(dst + offset, (void *) &pkt->crc, sizeof(pkt->crc));
+	offset += sizeof(pkt->crc);
 	
 	return offset;
 }
@@ -88,17 +91,63 @@ unsigned int serialize_command_packet(CommandPacket* pkt, uint8_t* dst) {
 unsigned int unpack_command_packet(CommandPacket* pkt, uint8_t* src) {
 	unsigned int offset = 0;
 
-	memcpy((void *) &pkt->start_char, src + offset, 2);
-	offset += 2;
+	memcpy((void *) &pkt->start_short, src + offset, sizeof(pkt->start_short));
+	offset += sizeof(pkt->start_short);
 
-	memcpy((void *) &pkt->function, src + offset, 1);
-	offset += 1;
+	memcpy((void *) &pkt->id, src + offset, sizeof(pkt->id));
+	offset += sizeof(pkt->id);
 
-	memcpy((void *) &pkt->arg, src + offset, 1);
-	offset += 1;
+	memcpy((void *) &pkt->function, src + offset, sizeof(pkt->function));
+	offset += sizeof(pkt->function);
 
-	memcpy((void *) &pkt->crc, src + offset, 2);
-	offset += 2;
+	memcpy((void *) &pkt->arg, src + offset, sizeof(pkt->arg));
+	offset += sizeof(pkt->arg);
+
+	memcpy((void *) &pkt->crc, src + offset, sizeof(pkt->crc));
+	offset += sizeof(pkt->crc);
+
+	return offset;
+}
+
+unsigned int serialize_ack_packet(AckPacket* pkt, uint8_t* dst) {
+	unsigned int offset = 0;
+	
+	memcpy(dst + offset, (void *) &pkt->start_short, sizeof(pkt->start_short));
+	offset += sizeof(pkt->start_short);
+
+	memcpy(dst + offset, (void *) &pkt->id, sizeof(pkt->id));
+	offset += sizeof(pkt->id);
+	
+	memcpy(dst + offset, (void *) &pkt->ack, sizeof(pkt->ack));
+	offset += sizeof(pkt->ack);
+	
+	memcpy(dst + offset, (void *) &pkt->nack, sizeof(pkt->nack));
+	offset += sizeof(pkt->nack);
+	
+	memcpy(dst + offset, (void *) &pkt->crc, sizeof(pkt->crc));
+	offset += sizeof(pkt->crc);
+	
+	return offset;
+}
+
+
+unsigned int unpack_ack_packet(AckPacket* pkt, uint8_t* src) {
+	unsigned int offset = 0;
+
+	memcpy((void *) &pkt->start_short, src + offset, sizeof(pkt->start_short));
+	offset += sizeof(pkt->start_short);
+
+	memcpy((void *) &pkt->id, src + offset, sizeof(pkt->id));
+	offset += sizeof(pkt->id);
+
+	memcpy((void *) &pkt->ack, src + offset, sizeof(pkt->ack));
+	offset += sizeof(pkt->ack);
+
+	memcpy((void *) &pkt->nack, src + offset, sizeof(pkt->nack));
+	offset += sizeof(pkt->nack);
+
+	memcpy((void *) &pkt->crc, src + offset, sizeof(pkt->crc));
+	offset += sizeof(pkt->crc);
 
 	return offset;
 }

--- a/rocket_packet.c
+++ b/rocket_packet.c
@@ -7,16 +7,16 @@
 
 #include "rocket_packet.h"
 
-unsigned int serialize_avionics_data(AvionicsData* data, uint8_t* dst) {
+unsigned int pack_avionics_data(AvionicsData* data, uint8_t* dst) {
 	/*
 	 * copy the rocket packet struct into the destination char array
 	 */
 	size_t i;
 	size_t offset = 0;
-	char start_short = ROCKET_PACKET_START;
+	char start_char = ROCKET_PACKET_START;
 
 	// start char
-	memcpy(dst + offset, (void *) &start_short, sizeof(char));
+	memcpy(dst + offset, (void *) &start_char, sizeof(char));
 	offset += sizeof(char);
 	// timestamp
 	memcpy(dst + offset, (void *) &data->timestamp, sizeof(data->timestamp));
@@ -66,7 +66,7 @@ unsigned int serialize_avionics_data(AvionicsData* data, uint8_t* dst) {
 	return offset;
 }
 
-unsigned int serialize_command_packet(CommandPacket* pkt, uint8_t* dst) {
+unsigned int pack_command_packet(CommandPacket* pkt, uint8_t* dst) {
 	unsigned int offset = 0;
 	
 	memcpy(dst + offset, (void *) &pkt->start_short, sizeof(pkt->start_short));
@@ -109,7 +109,7 @@ unsigned int unpack_command_packet(CommandPacket* pkt, uint8_t* src) {
 	return offset;
 }
 
-unsigned int serialize_ack_packet(AckPacket* pkt, uint8_t* dst) {
+unsigned int pack_ack_packet(AckPacket* pkt, uint8_t* dst) {
 	unsigned int offset = 0;
 	
 	memcpy(dst + offset, (void *) &pkt->start_short, sizeof(pkt->start_short));

--- a/rocket_packet.h
+++ b/rocket_packet.h
@@ -58,7 +58,6 @@ typedef struct {
 	int16_t z_gyro;
 } AvionicsData;
 
-
 typedef struct {
 	/* TODO: fix types and array sizes */
 	uint8_t valve_states[5];
@@ -67,7 +66,6 @@ typedef struct {
 	uint16_t piezoelectric;
 } MotorData;
 
-
 typedef struct {
 	AvionicsData avionics_data;
 	MotorData motor_data;
@@ -75,14 +73,21 @@ typedef struct {
 	uint16_t crc;
 } RocketPacket;
 
-
 typedef struct {
-	uint16_t start_char;
+	uint16_t start_short;
+	uint16_t id;
 	uint8_t function;
 	uint8_t arg;
 	uint16_t crc;
 } CommandPacket;
 
+typedef struct {
+	uint16_t start_short;
+	uint16_t id;
+	uint8_t ack;
+	uint8_t nack;
+	uint16_t crc;
+} AckPacket;
 
 /*
  * Serialize the rocket packet for transmission.

--- a/rocket_packet.h
+++ b/rocket_packet.h
@@ -85,20 +85,38 @@ typedef struct {
 	uint16_t start_short;
 	uint16_t id;
 	uint8_t ack;
-	uint8_t nack;
-	uint16_t crc;
+	uint8_t padd[3];
+	uint16_t *crc;
+	uint8_t *padd[2];
 } AckPacket;
+
+unsigned char data[7];
+ack.crc = &data[5];
+compute_crc(data)
+*ack.crc  == data[5, 6]
+
+reg[72]
+
+float* x;
+x = reg[53];
+
+
+
 
 /*
  * Serialize the rocket packet for transmission.
  */
-unsigned int serialize_rocket_packet(RocketPacket* pkt, uint8_t* dst);
+unsigned int pack_rocket_packet(RocketPacket* pkt, uint8_t* dst);
 
-unsigned int serialize_avionics_data(AvionicsData* data, uint8_t* dst);
+unsigned int pack_avionics_data(AvionicsData* data, uint8_t* dst);
 
-unsigned int serialize_motor_data(MotorData* data, uint8_t* dst);
+unsigned int pack_motor_data(MotorData* data, uint8_t* dst);
 
-unsigned int serialize_command_packet(CommandPacket* pkt, uint8_t* dst);
+unsigned int pack_command_packet(CommandPacket* pkt, uint8_t* dst);
+
+unsigned int pack_ack_packet(AckPacket* pkt, uint8_t* dst);
+
+unsigned int unpack_ack_packet(AckPacket* pkt, uint8_t* src);
 
 unsigned int unpack_command_packet(CommandPacket* pkt, uint8_t* src);
 


### PR DESCRIPTION
… command_packet. changed hardcoded values in serialize and unpack command packet functions (size = 2) to sizeof's [sizeof(plt->start_short)]. changed the name of start_char to start_short, because it is a uint16_t and not a uint8_t. farewell.